### PR TITLE
CLISP doesn't know :UTF-8 external format

### DIFF
--- a/quri.asd
+++ b/quri.asd
@@ -45,7 +45,7 @@
                              (or *load-pathname* *compile-file-pathname*))
                             :if-does-not-exist nil
                             :direction :input
-                            :external-format #+clisp 'charset:utf-8 #-clisp :utf8)
+                            :external-format #+clisp charset:utf-8 #-clisp :utf8)
       (when stream
         (let ((seq (make-array (file-length stream)
                                :element-type 'character


### PR DESCRIPTION
quri and dependent libraries now fail on CLISP due to the :UTF-8 usage:
http://cl-test-grid.appspot.com/blob?key=16617jgw5i

I suggest to change to `#+clisp 'charset:utf-8 #-clisp :utf8`

CLISP docs: http://www.clisp.org/impnotes/encoding.html
