### PR TITLE
Not sure if this belongs in clack or quri

### DIFF
--- a/src/decode.lisp
+++ b/src/decode.lisp
@@ -83,25 +83,26 @@
 ;; data before it collides with this error to pre-emptively clean it up
 (defun clean-up-malformed-data (data &key (delimiter #\&))
   "Some data sent in like a==b or a&&b will wreck this, so clean it up"
-  (let ((saw-equals nil)
-        (saw-delimiter nil)
-        (saw-safe t)
-        (data (string-trim (list #\= delimiter) data)))
-    (format
-     nil "~{~a~}"
-     (remove nil (loop for c across data
-                    collect
-                      (cond ((equal delimiter c)
-                             (when (and saw-safe (not saw-delimiter))
-                               (setf saw-safe nil
-                                     saw-delimiter t) c))
-                            ((equal #\= c)
-                             (when (and (not saw-equals) saw-safe)
-                               (setf saw-safe nil
-                                     saw-equals t) c))
-                            (t (setf saw-safe t
-                                     saw-delimiter nil
-                                     saw-equals nil) c)))))))
+  (unless (equal #\= delimiter) ;; Just testing if this is an issue
+    (let ((saw-equals nil)
+          (saw-delimiter nil)
+          (saw-safe t)
+          (data (string-trim (list #\= delimiter) data)))
+      (format
+       nil "~{~a~}"
+       (remove nil (loop for c across data
+                      collect
+                        (cond ((equal delimiter c)
+                               (when (and saw-safe (not saw-delimiter))
+                                 (setf saw-safe nil
+                                       saw-delimiter t) c))
+                              ((equal #\= c)
+                               (when (and (not saw-equals) saw-safe)
+                                 (setf saw-safe nil
+                                       saw-equals t) c))
+                              (t (setf saw-safe t
+                                       saw-delimiter nil
+                                       saw-equals nil) c))))))))
 
 (defun url-decode-params (data &key
                                  (delimiter #\&)

--- a/src/decode.lisp
+++ b/src/decode.lisp
@@ -83,7 +83,8 @@
 ;; data before it collides with this error to pre-emptively clean it up
 (defun clean-up-malformed-data (data &key (delimiter #\&))
   "Some data sent in like a==b or a&&b will wreck this, so clean it up"
-  (let ((last-c (char data 0))) ;; Checks for a string starting with = or delimiter
+  (let ((last-c nil)
+        (data (string-trim (list #\= delimiter) data)))
     (format nil "~{~a~}"
             (remove nil (loop for c across data
                            collect (unless (and (equal last-c c)

--- a/src/decode.lisp
+++ b/src/decode.lisp
@@ -77,6 +77,20 @@
            (error 'url-decoding-error)))))
     (babel:octets-to-string buffer :end i :encoding encoding)))
 
+;; If malformed data comes in (format a==b) this dies, and that causes the web server to
+;; run out of threads - wouldn't a more sensible default be to attempt a clean up vs error?
+;; especially as it seems like clack/caveman2 has no way for the implentor to touch the GET/POST
+;; data before it collides with this error to pre-emptively clean it up
+(defun clean-up-malformed-data (data &key (delimiter #\&))
+  "Some data sent in like a==b or a&&b will wreck this, so clean it up"
+  (let ((last-c nil))
+    (format nil "~{~a~}"
+            (remove nil (loop for c across data
+                           collect (unless (and (equal last-c c)
+                                                (member c (list #\= delimiter)))
+                                     (setf last-c c)
+                                     c))))))
+
 (defun url-decode-params (data &key
                                  (delimiter #\&)
                                  (encoding babel-encodings:*default-character-encoding*)
@@ -88,7 +102,8 @@
            (optimize (speed 3) (safety 2)))
   (let ((end (or end (length data)))
         (start-mark nil)
-        (=-mark nil))
+        (=-mark nil)
+        (data (clean-up-malformed-data data))) ;; Clean up malformed data to avoid blocking errors
     (declare (type integer end))
     (collecting
       (flet ((collect-pair (p)

--- a/src/decode.lisp
+++ b/src/decode.lisp
@@ -83,14 +83,25 @@
 ;; data before it collides with this error to pre-emptively clean it up
 (defun clean-up-malformed-data (data &key (delimiter #\&))
   "Some data sent in like a==b or a&&b will wreck this, so clean it up"
-  (let ((last-c nil)
+  (let ((saw-equals nil)
+        (saw-delimiter nil)
+        (saw-safe t)
         (data (string-trim (list #\= delimiter) data)))
-    (format nil "~{~a~}"
-            (remove nil (loop for c across data
-                           collect (unless (and (equal last-c c)
-                                                (member c (list #\= delimiter)))
-                                     (setf last-c c)
-                                     c))))))
+    (format
+     nil "~{~a~}"
+     (remove nil (loop for c across data
+                    collect
+                      (cond ((equal delimiter c)
+                             (when (and saw-safe (not saw-delimiter))
+                               (setf saw-safe nil
+                                     saw-delimiter t) c))
+                            ((equal #\= c)
+                             (when (and (not saw-equals) saw-safe)
+                               (setf saw-safe nil
+                                     saw-equals t) c))
+                            (t (setf saw-safe t
+                                     saw-delimiter nil
+                                     saw-equals nil) c)))))))
 
 (defun url-decode-params (data &key
                                  (delimiter #\&)

--- a/src/decode.lisp
+++ b/src/decode.lisp
@@ -83,7 +83,7 @@
 ;; data before it collides with this error to pre-emptively clean it up
 (defun clean-up-malformed-data (data &key (delimiter #\&))
   "Some data sent in like a==b or a&&b will wreck this, so clean it up"
-  (let ((last-c nil))
+  (let ((last-c (char data 0))) ;; Checks for a string starting with = or delimiter
     (format nil "~{~a~}"
             (remove nil (loop for c across data
                            collect (unless (and (equal last-c c)
@@ -100,10 +100,10 @@
            (type integer start)
            (type character delimiter)
            (optimize (speed 3) (safety 2)))
-  (let ((end (or end (length data)))
-        (start-mark nil)
-        (=-mark nil)
-        (data (clean-up-malformed-data data :delimiter delimiter))) ;; Clean up malformed data to avoid blocking errors
+  (let* ((data (clean-up-malformed-data data :delimiter delimiter)) ;; Clean up malformed data to avoid blocking errors
+         (end (or end (length data)))
+         (start-mark nil)
+         (=-mark nil))
     (declare (type integer end))
     (collecting
       (flet ((collect-pair (p)

--- a/src/decode.lisp
+++ b/src/decode.lisp
@@ -103,7 +103,7 @@
   (let ((end (or end (length data)))
         (start-mark nil)
         (=-mark nil)
-        (data (clean-up-malformed-data data))) ;; Clean up malformed data to avoid blocking errors
+        (data (clean-up-malformed-data data :delimiter delimiter))) ;; Clean up malformed data to avoid blocking errors
     (declare (type integer end))
     (collecting
       (flet ((collect-pair (p)


### PR DESCRIPTION
When quri throws up the malformed-uri errors, it seems to block clack's web server (hunchentoot etc.) - when enough build up, the server becomes unresponsive and refuses to create further threads.

Obviously this is terrible in a non-interactive environment (like running the app through sbcl as an auto-started daemon).

I don't see a way through caveman2 to parse GET/POST parameters before clack/quri get their hands on them, so this seems like the best option (I think removing duplicate "==" or delimiters like "&&" and replacing with singles is superior to just throwing errors).

Thoughts?