### PR TITLE
fix parsing when only scheme is present

### DIFF
--- a/src/parser.lisp
+++ b/src/parser.lisp
@@ -395,7 +395,11 @@
 
   (:eof
    (unless authority-mark
-     (return-from parse-authority))
+     (return-from parse-authority
+       (values data
+               nil nil
+               p p
+               nil nil)))
    (if colon-mark
        (setq host-start authority-mark
              host-end colon-mark

--- a/t/quri.lisp
+++ b/t/quri.lisp
@@ -46,7 +46,9 @@
     ("http://[dead:beef::]:/foo/" .
      ("http" nil "[dead:beef::]" "/foo/" nil nil))
     ("tel:+31-641044153" .
-     ("tel" nil nil "+31-641044153" nil nil))))
+     ("tel" nil nil "+31-641044153" nil nil))
+    ("http://" .
+     ("http" nil nil nil nil nil))))
 
 (loop for (test-uri . params) in *test-cases* do
   (subtest (format nil "~A (string)" test-uri)


### PR DESCRIPTION
Before:

```Lisp
(quri:parse-uri "amqp://")
"amqp"
NIL
NIL
NIL
"//"
NIL
NIL
```

As you can see `path` part is not empty and equals to "//"
After fix:

```Lisp
(quri:parse-uri "amqp://")
"amqp"
NIL
NIL
NIL
NIL
NIL
NIL
```
