### PR TITLE
Read effective TLDs at read time

### DIFF
--- a/src/etld.lisp
+++ b/src/etld.lisp
@@ -39,9 +39,9 @@
                  *wildcard-tlds* wildcard-tlds)))))
 
 (setf (values *normal-tlds* *wildcard-tlds* *special-tlds*)
-      #.(let (*normal-tlds* *wildcard-tlds* *special-tlds*)
-          (load-etld-data)
-          (values *normal-tlds* *wildcard-tlds* *special-tlds*)))
+      (values-list '#.(let (*normal-tlds* *wildcard-tlds* *special-tlds*)
+                        (load-etld-data)
+                        (list *normal-tlds* *wildcard-tlds* *special-tlds*))))
 
 (defun next-subdomain (hostname &optional (start 0))
   (let ((pos (position #\. hostname :start start)))

--- a/src/etld.lisp
+++ b/src/etld.lisp
@@ -31,7 +31,9 @@
                (setf (gethash line normal-tlds) t)))
          finally (return (list normal-tlds wildcard-tlds special-tlds))))))
 
-(defvar *etlds* '#.(load-etld-data))
+(defvar *etlds*
+  #-abcl '#.(load-etld-data)
+  #+abcl (load-etld-data))
 
 (defun next-subdomain (hostname &optional (start 0))
   (let ((pos (position #\. hostname :start start)))


### PR DESCRIPTION
I ran into this problem with quri while creating an application binary using ECL. In a nutshell, in `etld.lisp`, quri tries to read a data file relative to its ASDF system definition pathname at LOAD time. This is problematic for ECL which doesn't really create a Lisp image but instead "compiles software as you would with GCC and other languages which bootstrap image from scratch".  Which means that the Lisp source code is only compiled into the binary, loading happens at the time the program is run.

Specifically, this leads to two problems:

1. The data file is not found while running the program since correct ASDF paths are not set (there is no quicklisp in the binary).
2. Even if you can fix this, the second problem is that the target system where the binary is run may not have quri, so the data file won't even exist there.

A bug report I filed in the ECL project has more details: https://gitlab.com/embeddable-common-lisp/ecl/issues/456

I can think of a couple of ways to fix this. This PR is one attempt which just reads effective_tld_names.dat at read time. Not sure if the changes are acceptable to be merged upstream but more importantly I wanted to highlight the issue and hope that it can be resolved in some way. 