### PR TITLE
Revises uri-query-params behavior with NIL

### DIFF
--- a/src/uri/http.lisp
+++ b/src/uri/http.lisp
@@ -34,4 +34,6 @@
     (url-decode-params query)))
 
 (defun (setf uri-query-params) (new http)
-  (setf (uri-query http) (url-encode-params new)))
+  (setf (uri-query http) (if new
+			     (url-encode-params new)
+			     nil)))


### PR DESCRIPTION
Setting the query slot via `uri-query-params` using NIL results in the query slot assuming a non-NIL value. From my perspective, this behavior seems a bit counterintuitive.

```lisp
(let ((quri-uri-object (quri:uri "tests")))
  (describe quri-uri-object)		;query value is NIL
  (setf (quri:uri-query-params quri-uri-object)
	nil)
  (describe quri-uri-object)		;query value is non-NIL
  (quri:render-uri quri-uri-object)	;rendered with '?' char appended
  )
```