### PR TITLE
Add test for ipv6 domains that are too long

### DIFF
--- a/src/domain.lisp
+++ b/src/domain.lisp
@@ -112,7 +112,7 @@
                              (length string)
                              end)))
                (declare (type fixnum end))
-               
+
                (do ((i start (1+ i)))
                    ((= end i))
                  (let ((ch (aref string i)))
@@ -147,6 +147,8 @@
                        (not read-colons))
               (return-from ipv6-addr-p nil))
             (return-from ipv6-addr-p t))
+          (when (and (= i 7) (not endp))
+            (return-from ipv6-addr-p nil))
           (setq start e
                 read-colons-p read-colons))))))
 

--- a/t/domain.lisp
+++ b/t/domain.lisp
@@ -34,7 +34,8 @@
   (ok (ipv6-addr-p "2001:db8::9abc"))
   (ok (ipv6-addr-p "::1"))
   (ok (ipv6-addr-p "::"))
-  (ok (ipv6-addr-p "1::")))
+  (ok (ipv6-addr-p "1::"))
+  (ok (not (ipv6-addr-p "1:1:1:1:1:1:1:1:1:1:1:1:1:1:1:1"))))
 
 (subtest "ip-addr="
   (is (ip-addr= "127.0.0.1" "127.0.0.1") t)


### PR DESCRIPTION
Hello,

I was working on another project that was using quri to validate ip addresses that had an independently maintained test suite and the ipv6 validation failed.  It turns out quri only checks ipv6 addresses are valid up to the first 8 segments and doesn't care if there are more.

This makes it return `nil` if there are more than 8 segments (if I understand the function correctly, it's very optimized).