### PR TITLE
Preserve case in render-uri for file:// URIs

### DIFF
--- a/src/quri.lisp
+++ b/src/quri.lisp
@@ -170,7 +170,7 @@
              (uri-fragment uri)))
     ((uri-file-p uri)
      (format stream
-             "~@[~(~A~)://~]~@[~(~a~)~]"
+             "~@[~(~A~)://~]~@[~a~]"
              (uri-scheme uri)
              (uri-path uri)))
     (t


### PR DESCRIPTION
Fixes https://github.com/atlas-engineer/nyxt/issues/974.