### PR TITLE
Fix authority parsing

### DIFF
--- a/src/parser.lisp
+++ b/src/parser.lisp
@@ -368,7 +368,8 @@
 
   (parsing-authority-starting
    (unless (char=* char #\/)
-     (error 'uri-malformed-string :data data :position p))
+     (return-from parse-authority
+        (values data nil nil start start nil nil)))
    (gonext))
 
   (parsing-authority-start

--- a/t/quri.lisp
+++ b/t/quri.lisp
@@ -62,7 +62,9 @@
     ("http://" .
      ("http" nil nil nil nil nil))
     ("foo:/a/b/c" .
-     ("foo" nil nil "/a/b/c" nil nil))))
+     ("foo" nil nil "/a/b/c" nil nil))
+    ("//foo/bar" .
+     (nil nil "foo" "/bar" nil nil))))
 
 (loop for (test-uri . params) in *test-cases* do
   (subtest (format nil "~A (string)" test-uri)

--- a/t/quri.lisp
+++ b/t/quri.lisp
@@ -60,7 +60,9 @@
     ("tel:+31-641044153" .
      ("tel" nil nil "+31-641044153" nil nil))
     ("http://" .
-     ("http" nil nil nil nil nil))))
+     ("http" nil nil nil nil nil))
+    ("foo:/a/b/c" .
+     ("foo" nil nil "/a/b/c" nil nil))))
 
 (loop for (test-uri . params) in *test-cases* do
   (subtest (format nil "~A (string)" test-uri)


### PR DESCRIPTION
This fixes 2 bugs around the parsing of the authority component:
1. The authority component can be empty, as in `scheme:/path`.
2. There can be an authority without a scheme (in a relative reference URI).