### PR TITLE
Handle strings and byte vectors in query values, and nothing else

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -64,7 +64,7 @@ Create a `uri` object.
 ;=> #<QURI.URI.HTTP:URI-HTTP http://8arrow.org/>
 
 (make-uri :defaults "http://8arrow.org"
-          :query '(("guest" . 1)))
+          :query '(("guest" . "1")))
 ;=> #<QURI.URI.HTTP:URI-HTTP http://8arrow.org?guest=1>
 ```
 

--- a/quri.asd
+++ b/quri.asd
@@ -32,7 +32,7 @@
                  (:file "etld")
                  (:file "parser" :depends-on ("error" "util"))
                  (:file "decode" :depends-on ("error" "util"))
-                 (:file "encode")
+                 (:file "encode" :depends-on ("error" "util"))
                  (:file "port")
                  (:file "util")
                  (:file "error"))))

--- a/src/decode.lisp
+++ b/src/decode.lisp
@@ -34,7 +34,7 @@
                           (start 0)
                           end
                           (lenient nil))
-  (declare (type (or string (simple-array (unsigned-byte 8) (*))) data)
+  (declare (type (or string simple-byte-vector) data)
            (type integer start)
            (optimize (speed 3) (safety 2)))
   (let* ((end (or end (length data)))
@@ -43,7 +43,7 @@
          (i 0)
          parsing-encoded-part)
     (declare (type integer end i)
-             (type (simple-array (unsigned-byte 8)) buffer))
+             (type simple-byte-vector buffer))
     (flet ((write-to-buffer (byte)
              (declare (optimize (speed 3) (safety 0)))
              (setf (aref buffer i) byte)
@@ -92,7 +92,7 @@
                                  (start 0)
                                  end
                                  (lenient nil))
-  (declare (type (or string (simple-array (unsigned-byte 8) (*))) data)
+  (declare (type (or string simple-byte-vector) data)
            (type integer start)
            (type character delimiter)
            (optimize (speed 3) (safety 2)))

--- a/src/encode.lisp
+++ b/src/encode.lisp
@@ -97,9 +97,10 @@
       (write-string (url-encode field :encoding encoding :space-to-plus space-to-plus) s)
       (when value
         (write-char #\= s)
-        (write-string (url-encode (if (stringp value)
-                                      value
-                                      (write-to-string value))
-                                  :encoding encoding :space-to-plus space-to-plus) s))
+        (check-type value (or string simple-byte-vector))
+        (write-string (url-encode value
+                                  :encoding encoding
+                                  :space-to-plus space-to-plus)
+                      s))
       (when rest
         (write-char #\& s)))))

--- a/src/encode.lisp
+++ b/src/encode.lisp
@@ -1,6 +1,7 @@
 (in-package :cl-user)
 (defpackage quri.encode
-  (:use :cl)
+  (:use :cl
+        :quri.util)
   (:import-from :babel-encodings
                 :*default-character-encoding*)
   (:export :url-encode
@@ -47,7 +48,7 @@
                           (start 0)
                           end
                           space-to-plus)
-  (declare (type (or string (simple-array (unsigned-byte 8) (*))) data)
+  (declare (type (or string simple-byte-vector) data)
            (type integer start)
            (optimize (speed 3) (safety 2)))
   (let* ((octets (if (stringp data)
@@ -55,7 +56,7 @@
                      data))
          (res (make-array (* (length octets) 3) :element-type 'character :fill-pointer t))
          (i 0))
-    (declare (type (simple-array (unsigned-byte 8) (*)) octets)
+    (declare (type simple-byte-vector octets)
              (type string res)
              (type integer i))
     (loop for byte of-type (unsigned-byte 8) across octets do

--- a/src/parser.lisp
+++ b/src/parser.lisp
@@ -20,8 +20,6 @@
            :parse-fragment))
 (in-package :quri.parser)
 
-(deftype simple-byte-vector (&optional (len '*)) `(simple-array (unsigned-byte 8) (,len)))
-
 (declaim (type (simple-array fixnum (128)) +uri-char+))
 (define-constant +uri-char+
     (let ((uri-char (make-array 128 :element-type 'fixnum :initial-element 0)))

--- a/src/util.lisp
+++ b/src/util.lisp
@@ -3,7 +3,8 @@
   (:use :cl)
   (:import-from :alexandria
                 :with-gensyms)
-  (:export :standard-alpha-char-p
+  (:export :simple-byte-vector
+           :standard-alpha-char-p
            :standard-alpha-byte-p
            :standard-alphanumeric-p
            :standard-alphanumeric-byte-p
@@ -14,6 +15,8 @@
            :gonext
            :goto))
 (in-package :quri.util)
+
+(deftype simple-byte-vector (&optional (len '*)) `(simple-array (unsigned-byte 8) (,len)))
 
 (defun standard-alpha-char-p (char)
   (declare (type character char)

--- a/t/encode.lisp
+++ b/t/encode.lisp
@@ -17,6 +17,10 @@
 
 (subtest "url-encode-params"
   (is (url-encode-params '(("a" . "b") ("c" . "d")))
-      "a=b&c=d"))
+      "a=b&c=d")
+  (is (url-encode-params
+       `(("a" . ,(make-array 1 :element-type '(unsigned-byte 8)
+                               :initial-contents (list (char-code #\b))))))
+      "a=b"))
 
 (finalize)


### PR DESCRIPTION
When encoding query values, don't try to convert a value to a string when we don't know what else to do with it: handle strings and byte vectors, and error out on anything else. (Fixes #30.)

This also replaces all uses of `(simple-array (unsigned-byte 8) (*))` by `simple-byte-vector`, a type that was defined and used in `parser.lisp` but not anywhere else. This type is now exported from `quri.util` and used pervasively.