### PR TITLE
Fix handling of :end argument in parse-uri.

### DIFF
--- a/src/parser.lisp
+++ b/src/parser.lisp
@@ -168,7 +168,7 @@
                  (declare (type simple-byte-vector data)
                           (type fixnum start))
                  (multiple-value-bind (data start end)
-                     (parse-path-byte-vector data :start start)
+                     (parse-path-byte-vector data :start start :end parse-end)
                    (declare (type fixnum start end))
                    (unless (= start end)
                      (setq path (subseq* data start end)))

--- a/src/parser.lisp
+++ b/src/parser.lisp
@@ -79,7 +79,7 @@
                (declare (type simple-string data)
                         (type fixnum start))
                (multiple-value-bind (data start end)
-                   (parse-path-string data :start start)
+                   (parse-path-string data :start start :end parse-end)
                  (declare (type simple-string data)
                           (type fixnum start end))
                  (unless (= start end)

--- a/t/parser.lisp
+++ b/t/parser.lisp
@@ -7,4 +7,10 @@
 
 (plan nil)
 
+(subtest "parser string bounds"
+  (is (nth-value 0 (parse-uri "foo://bar" :start 4)) nil)
+  (is (nth-value 4 (parse-uri "foo://bar/xyz?a=b#c" :end 12)) "/xy")
+  (is (nth-value 5 (parse-uri "foo://bar/xyz?a=b#c" :end 13)) nil)
+  (is (nth-value 6 (parse-uri "foo://bar/xyz?a=b#c" :end 17)) nil))
+
 (finalize)


### PR DESCRIPTION
When parsing the path/query/fragment part, the parser ignores the `:end`
argument, which can signal an error on valid URIs such as "foobar" with `:end`
set to 3.