### PR TITLE
Ensure uri-path is always a string

### DIFF
--- a/src/parser.lisp
+++ b/src/parser.lisp
@@ -81,8 +81,9 @@
                    (parse-path-string data :start start :end parse-end)
                  (declare (type simple-string data)
                           (type fixnum start end))
-                 (unless (= start end)
-                   (setq path (subseq data start end)))
+                 (setq path (if (= start end)
+                                ""
+                                (subseq data start end)))
                  ;; Pitfall: There may be no query but a fragment that has a '?', e.g.
                  ;; https://example.org/#/?b
                  (let ((maybe-query-start (or (nth-value 1 (parse-query-string data :start end :end parse-end))

--- a/src/uri.lisp
+++ b/src/uri.lisp
@@ -27,18 +27,13 @@
   userinfo
   host
   port
-  path
+  (path "")
   query
   fragment)
 
-(defun make-basic-uri (&key scheme userinfo host port path query fragment)
-  (let ((uri (%make-uri :scheme scheme
-                        :userinfo userinfo
-                        :host host
-                        :port port
-                        :path path
-                        :query query
-                        :fragment fragment)))
+(defun make-basic-uri (&rest args &key scheme userinfo host port path query fragment)
+  (declare (ignore scheme userinfo host port path query fragment))
+  (let ((uri (apply #'%make-uri args)))
     (unless (uri-port uri)
       (setf (uri-port uri)
             (scheme-default-port (uri-scheme uri))))
@@ -60,7 +55,7 @@
 
 (defun make-urn (&rest initargs)
   (let ((urn (apply #'%make-urn initargs)))
-    (when (uri-path urn)
+    (unless (uiop:emptyp (uri-path urn))
       (let ((colon-pos (position #\: (uri-path urn))))
         (if colon-pos
             (setf (urn-nid urn) (subseq (uri-path urn) 0 colon-pos)

--- a/src/uri/ftp.lisp
+++ b/src/uri/ftp.lisp
@@ -22,7 +22,7 @@
   (let ((ftp (apply #'%make-uri-ftp initargs)))
     (multiple-value-bind (path typecode)
         (parse-ftp-typecode (uri-path ftp))
-      (when path
+      (unless (uiop:emptyp path)
         (setf (uri-path ftp) path
               (uri-ftp-typecode ftp) typecode)))
     ftp))

--- a/src/uri/ldap.lisp
+++ b/src/uri/ldap.lisp
@@ -34,7 +34,7 @@
 
 (defun uri-ldap-dn (ldap)
   (let ((path (uri-path ldap)))
-    (when (and path
+    (when (and (not (uiop:emptyp path))
                (/= 0 (length path)))
       (if (char= (aref path 0) #\/)
           (subseq path 1)

--- a/t/quri.lisp
+++ b/t/quri.lisp
@@ -40,11 +40,11 @@
     ("git+ssh://git@github.com/user/project.git" .
      ("git+ssh" "git" "github.com" "/user/project.git" nil nil))
     ("http://common-lisp.net" .
-     ("http" nil "common-lisp.net" nil nil nil))
+     ("http" nil "common-lisp.net" "" nil nil))
     ("http://common-lisp.net#abc" .
-     ("http" nil "common-lisp.net" nil nil "abc"))
+     ("http" nil "common-lisp.net" "" nil "abc"))
     ("http://common-lisp.net?q=abc" .
-     ("http" nil "common-lisp.net" nil "q=abc" nil))
+     ("http" nil "common-lisp.net" "" "q=abc" nil))
     ("http://common-lisp.net/#abc" .
      ("http" nil "common-lisp.net" "/" nil "abc"))
     ("http://a/b/c/d;p?q#f" .
@@ -52,7 +52,7 @@
     ("http" .
      (nil nil nil "http" nil nil))
     ("http:" .
-     ("http" nil nil nil nil nil))
+     ("http" nil nil "" nil nil))
     ("ldap://[2001:db8::7]/c=GB?objectClass?one" .
      ("ldap" nil "[2001:db8::7]" "/c=GB" "objectClass?one" nil))
     ("http://[dead:beef::]:/foo/" .
@@ -60,7 +60,7 @@
     ("tel:+31-641044153" .
      ("tel" nil nil "+31-641044153" nil nil))
     ("http://" .
-     ("http" nil nil nil nil nil))
+     ("http" nil nil "" nil nil))
     ("foo:/a/b/c" .
      ("foo" nil nil "/a/b/c" nil nil))
     ("//foo/bar" .


### PR DESCRIPTION
This is less surprising to the caller, thus removing a whole class of
programming errors.

Should fix #44.

Note this is API-breaking (I had to edit a few tests).

If this is accepted, I'll forward the change to the other slots (scheme, userinfo, host, query, fragment -- but not port) to remove type ambiguity.

Should unspecified port be 0 instead of NIL?

@fukamachi Thoughts?