### PR TITLE
Fix spurious discarding of ":" and "/" in some cases

### DIFF
--- a/src/parser.lisp
+++ b/src/parser.lisp
@@ -107,7 +107,8 @@
               (locally (declare (type fixnum start end))
                 (setq scheme
                       (or got-scheme
-                          (string-downcase (subseq data start end)))))
+                          (string-downcase (subseq data start end))))
+                (incf end))             ;eat the trailing #\:
               (setq scheme nil
                     end parse-start))
           (locally (declare (type fixnum end))
@@ -197,7 +198,8 @@
                                     (code-char
                                      (if (<= #.(char-code #\A) code #.(char-code #\Z))
                                          (+ code 32)
-                                         code)))))))))
+                                         code))))))))
+                  (incf end))           ;eat the trailing #\:
                 (setq scheme nil
                       end parse-start))
             (locally (declare (type fixnum end))
@@ -364,9 +366,6 @@
                                                 port-end)
   (parsing-first
    (cond
-     ((char=* char #\:)
-      (incf start)
-      (redo))
      ((char=* char #\/)
       (gonext))
      (t

--- a/src/parser.lisp
+++ b/src/parser.lisp
@@ -135,7 +135,7 @@
                       (scheme
                        (setq port (scheme-default-port scheme))))))
                 (locally (declare (optimize (safety 0)))
-                  (parse-from-path data (or port-end host-end (1+ end))))))))))
+                  (parse-from-path data (or port-end host-end end)))))))))
     (values scheme userinfo host port path query fragment)))
 
 (defun parse-uri-byte-vector (data &key (start 0) end)
@@ -376,10 +376,10 @@
    (unless (char=* char #\/)
      (return-from parse-authority
         (values data nil nil start start nil nil)))
+   (setq authority-mark (1+ p))
    (gonext))
 
   (parsing-authority-start
-   (setq authority-mark p)
    (if (char=* char #\[)
        (goto parsing-ipliteral)
        (gonext 0)))
@@ -419,7 +419,7 @@
      (return-from parse-authority
        (values data
                nil nil
-               p p
+               start start
                nil nil)))
    (if colon-mark
        (setq host-start authority-mark

--- a/t/quri.lisp
+++ b/t/quri.lisp
@@ -65,6 +65,16 @@
      ("foo" nil nil "/a/b/c" nil nil))
     ("foo::" .
      ("foo" nil nil ":" nil nil))
+    ("/" .
+     (nil nil nil "/" nil nil))
+    ("foo:/" .
+     ("foo" nil nil "/" nil nil))
+    ("//a/" .
+     (nil nil "a" "/" nil nil))
+    ("//" .
+     (nil nil nil nil nil nil))
+    ("///" .
+     (nil nil nil "/" nil nil))
     ("//foo/bar" .
      (nil nil "foo" "/bar" nil nil))))
 

--- a/t/quri.lisp
+++ b/t/quri.lisp
@@ -63,6 +63,8 @@
      ("http" nil nil nil nil nil))
     ("foo:/a/b/c" .
      ("foo" nil nil "/a/b/c" nil nil))
+    ("foo::" .
+     ("foo" nil nil ":" nil nil))
     ("//foo/bar" .
      (nil nil "foo" "/bar" nil nil))))
 


### PR DESCRIPTION
This fixes two classes of bugs regarding paths:

- `(parse-uri "foo::")` returns an empty path when it should return `":"`
- `(parse-uri "foo:/")` and `(parse-uri "/")` return an empty path when they should return `"/"`

Fixes #49
Fixes #47 