### PR TITLE
Remove dot segments when merging a relative URI with a scheme.

### DIFF
--- a/src/quri.lisp
+++ b/src/quri.lisp
@@ -261,17 +261,21 @@ mutated."
     (when (uri-equal reference base)
       (return-from merge-uris base))
 
-    ;; Step 3 -- scheme
-    (when (uri-scheme reference)
-      (return-from merge-uris reference))
-    (let ((uri (copy-uri reference :scheme (uri-scheme base))))
-      (when (null (uri-port uri))
-        (setf (uri-port uri) (scheme-default-port (uri-scheme uri))))
+    (let ((uri (copy-uri reference)))
       (flet ((done () (return-from merge-uris uri))
              (remove-dot-segments ()
                (setf (uri-path uri) (merge-uri-paths (uri-path uri) nil))))
 
+        ;; Step 3 -- scheme
+        (when (uri-scheme uri)
+          (remove-dot-segments)
+          (done))
+        (setf (uri-scheme uri) (uri-scheme base))
+
         ;; Step 4 -- Authority
+        (when (null (uri-port uri))
+          (setf (uri-port uri) (scheme-default-port (uri-scheme uri))))
+
         (when (uri-host uri)
           (remove-dot-segments)
           (done))

--- a/t/quri.lisp
+++ b/t/quri.lisp
@@ -121,6 +121,7 @@
     (,(uri "/./foo/") . "http://www.example.com/foo/")
     (,(uri "/x/../y/") . "http://www.example.com/y/")
     (,(uri "/x/../../../y/") . "http://www.example.com/y/")
+    (,(uri "foo://x/y/../z/") . "foo://x/z/")
     (,(make-uri :query "name=fukamachi") . "http://www.example.com/path/a/b.html?name=fukamachi")
     (,(make-uri :scheme "https" :host "foo.com" :path "foo/bar") . "https://foo.com/foo/bar")
     (,(uri "https://example.org/#/?b") . "https://example.org/#/?b")


### PR DESCRIPTION
Followup to the partial reversal of #52.