### PR TITLE
Prevent some functions from being affected by *PRINT-BASE*.

### DIFF
--- a/src/encode.lisp
+++ b/src/encode.lisp
@@ -99,7 +99,8 @@
         (write-char #\= s)
         (check-type value (or string number simple-byte-vector))
         (write-string (url-encode (if (numberp value)
-                                      (write-to-string value)
+                                      (with-standard-io-syntax
+                                        (write-to-string value))
                                       value)
                                   :encoding encoding
                                   :space-to-plus space-to-plus)

--- a/src/uri.lisp
+++ b/src/uri.lisp
@@ -47,11 +47,12 @@
 (defun uri-authority (uri)
   (when (uri-host uri)
     (let ((default-port (scheme-default-port (uri-scheme uri))))
-      (format nil "~:[~;~:*~A@~]~A~:[:~A~;~*~]"
-              (uri-userinfo uri)
-              (uri-host uri)
-              (eql (uri-port uri) default-port)
-              (uri-port uri)))))
+      (with-standard-io-syntax
+        (format nil "~:[~;~:*~A@~]~A~:[:~A~;~*~]"
+                (uri-userinfo uri)
+                (uri-host uri)
+                (eql (uri-port uri) default-port)
+                (uri-port uri))))))
 
 (defstruct (urn (:include uri (scheme :urn))
                 (:constructor %make-urn))

--- a/t/encode.lisp
+++ b/t/encode.lisp
@@ -23,6 +23,9 @@
                                :initial-contents (list (char-code #\b))))))
       "a=b")
   (is (url-encode-params '(("a" . "b") ("c" . 1)))
-      "a=b&c=1"))
+      "a=b&c=1")
+  (is (let ((*print-base* 2))
+        (url-encode-params '(("a" . 5))))
+      "a=5"))
 
 (finalize)

--- a/t/quri.lisp
+++ b/t/quri.lisp
@@ -132,4 +132,9 @@
        (let ((merged-uri (merge-uris test-uri *base-uri*)))
          (is (render-uri merged-uri) result-uri :test 'string=))))
 
+(subtest "render-uri"
+  (is (let* ((*print-base* 2))
+        (render-uri (uri "//foo:80?a=5")))
+      "//foo:80?a=5"))
+
 (finalize)


### PR DESCRIPTION
Functions `make-uri` and `uri-authority` build strings from a number, and don't take care to bind `*print-base*` to a sensible value:

```
(quri:uri-query-params
 (let ((*print-base* 2))
   (quri:make-uri :query '(("a" . 5)))))
;; => (("a" . "101"))

(let ((*print-base* 2))
  (quri:uri-authority (quri:uri "//foo:80")))
;; => "foo:1010000"
```
This PR fixes that problem.