### PR TITLE
Fix uri type and scheme mismatch

### DIFF
--- a/src/quri.lisp
+++ b/src/quri.lisp
@@ -269,7 +269,7 @@ mutated."
       (when (uri-scheme merged-uri)
           (merge-paths)
           (return-merged-uri))
-      (setf (uri-scheme merged-uri) (uri-scheme base))
+      (setf merged-uri (copy-uri merged-uri :scheme (uri-scheme base)))
       ;; Step 4
       (when (null (uri-port merged-uri))
         (setf (uri-port merged-uri) (scheme-default-port (uri-scheme merged-uri))))

--- a/src/uri.lisp
+++ b/src/uri.lisp
@@ -23,7 +23,7 @@
 (in-package :quri.uri)
 
 (defstruct (uri (:constructor %make-uri))
-  scheme
+  (scheme nil :read-only t)
   userinfo
   host
   port

--- a/t/quri.lisp
+++ b/t/quri.lisp
@@ -127,10 +127,14 @@
     (,(uri "https://example.org/#/?b") . "https://example.org/#/?b")
     (,(uri "about:blank") . "about:blank")))
 
-(subtest "merge-uris"
-  (loop for (test-uri . result-uri) in *merge-test-cases* do
-       (let ((merged-uri (merge-uris test-uri *base-uri*)))
-         (is (render-uri merged-uri) result-uri :test 'string=))))
+(loop for (test-uri . result-uri) in *merge-test-cases* do
+  (let ((merged-uri (merge-uris test-uri *base-uri*)))
+    (subtest "merge-uris"
+      (is (render-uri merged-uri) result-uri :test 'string=))
+    (subtest "merge-uris type checking"
+      (unless (uri-scheme test-uri)
+        (is (symbol-name (type-of merged-uri))
+            (symbol-name (type-of *base-uri*)))))))
 
 (subtest "render-uri"
   (is (let* ((*print-base* 2))


### PR DESCRIPTION
This a possible solution to solve #47.

The issue is not related to a bug in `merge-uris`, but due to a more general issue that I explain below.

There are several types in the library, that roughly correspond to different URI schemes.  When a URI is instantiated with no scheme and it is later assigned a scheme, it can happen that there's a mismatch. 

Example:

```lisp
(defvar test-uri (make-uri :path "/test"))
(setf (uri-scheme test-uri) "https")
(uri-https-p test-uri) -> nil
```

In this PR, I try to solve this issue. There might be better ways to go about it.

What do you think @Ambrevar?
