### PR TITLE
Add lenient &key argument to `uri-query-params` to control the query parsing.

### DIFF
--- a/src/uri/http.lisp
+++ b/src/uri/http.lisp
@@ -29,7 +29,7 @@
 
 (defstruct (uri-https (:include uri-http (scheme "https") (port #.(scheme-default-port "https")))))
 
-(defun uri-query-params (http &key lenient)
+(defun uri-query-params (http &key (lenient t))
   (when-let (query (uri-query http))
     (url-decode-params query :lenient lenient)))
 

--- a/src/uri/http.lisp
+++ b/src/uri/http.lisp
@@ -29,11 +29,12 @@
 
 (defstruct (uri-https (:include uri-http (scheme "https") (port #.(scheme-default-port "https")))))
 
-(defun uri-query-params (http)
+(defun uri-query-params (http &key lenient)
   (when-let (query (uri-query http))
-    (url-decode-params query)))
+    (url-decode-params query :lenient lenient)))
 
-(defun (setf uri-query-params) (new http)
+(defun (setf uri-query-params) (new http &key lenient)
+  (declare (ignore lenient))
   (setf (uri-query http) (if new
                              (url-encode-params new)
                              nil)))


### PR DESCRIPTION
This adds a keyword argument to control the lenient parsing of URI query parameters. The problem that prompted this addition was that the code snippet below produced `QURI.ERROR:URI-MALFORMED-URLENCODED-STRING` when ran against a URL found in the wild while browsing with Nyxt:
``` lisp
;; URL not real, used only for illustrative purposes.
(quri:uri-query-params (quri:uri "https://github.com?&helo=jsd"))
; Evaluation aborted on #<QURI.ERROR:URI-MALFORMED-URLENCODED-STRING {10024CD143}>

;; Newly-added :LENIENT keyword.
(quri:uri-query-params (quri:uri "https://github.com?&helo=jsd") :lenient t)
; => (("helo" . "jsd"))
```

While it may be possible to simply inline the `quri:uri-query-params` into the code that relies on it, with altered `url-decode-params` arguments (and I'd be totally fine if this PR is closed with inlining `uri-query-params` as a suggested alternative), this seems to be too much work for such a DWIM-ish operation as getting processed query params.

Does it look sane?