### PR TITLE
Support MSVC on ECL

### DIFF
--- a/src/etld.lisp
+++ b/src/etld.lisp
@@ -32,10 +32,8 @@
          finally (return (list normal-tlds wildcard-tlds special-tlds))))))
 
 (defvar *etlds*
-  (or
-    #+(and ecl win32 msvc) (load-etld-data)
-    #+abcl (load-etld-data)
-    #-(or abcl (and ecl win32 msvc)) '#.(load-etld-data)))
+    #+(or abcl (and ecl win32 msvc)) (load-etld-data)
+    #-(or abcl (and ecl win32 msvc)) '#.(load-etld-data))
 
 (defun next-subdomain (hostname &optional (start 0))
   (let ((pos (position #\. hostname :start start)))

--- a/src/etld.lisp
+++ b/src/etld.lisp
@@ -32,8 +32,10 @@
          finally (return (list normal-tlds wildcard-tlds special-tlds))))))
 
 (defvar *etlds*
-  #-abcl '#.(load-etld-data)
-  #+abcl (load-etld-data))
+  (or
+    #+(and ecl win32 msvc) (load-etld-data)
+    #+abcl (load-etld-data)
+    #-(or abcl (and ecl win32 msvc)) '#.(load-etld-data)))
 
 (defun next-subdomain (hostname &optional (start 0))
   (let ((pos (position #\. hostname :start start)))


### PR DESCRIPTION
On Windows, using the MSVC compiler tool chain, the reader macro `#.` used to load the ETLD data is problematic. It makes a large string in the C code, over 65k characters, which the `cl.exe` MSVC compiler is not able to handle :(

This PR fixes things so that `(asdf:load-system "quri")` works again with an MSVC-backed ECL instance.
