### PR TITLE
Coerce cl:pathname to string in URI path.

### DIFF
--- a/src/uri.lisp
+++ b/src/uri.lisp
@@ -36,6 +36,9 @@
   (let ((uri (apply #'%make-uri args)))
     (unless (uri-port uri)
       (setf (uri-port uri) (scheme-default-port (uri-scheme uri))))
+    (when (pathnamep (uri-path uri))
+      (setf (uri-path uri)
+            (uiop:native-namestring (uri-path uri))))
     uri))
 
 (defun uri-authority (uri)

--- a/src/uri/file.lisp
+++ b/src/uri/file.lisp
@@ -15,12 +15,11 @@
 (defstruct (uri-file (:include uri (scheme "file") (port nil))
                      (:constructor %make-uri-file)))
 
-(defun make-uri-file (&rest initargs)
-  (let ((uri (apply #'%make-uri-file initargs)))
-    (when (pathnamep (uri-path uri))
-      (setf (uri-path uri)
-            (uiop:native-namestring (uri-path uri))))
-    uri))
+(defun make-uri-file (&rest initargs &key path &allow-other-keys)
+  (when (pathnamep path)
+    (setf (getf initargs :path)
+          (uiop:native-namestring path)))
+  (apply #'%make-uri-file initargs))
 
 (declaim (ftype (function (uri-file) pathname) uri-file-pathname))
 (defun uri-file-pathname (file)

--- a/src/uri/file.lisp
+++ b/src/uri/file.lisp
@@ -12,7 +12,15 @@
            :uri-file-pathname))
 (in-package :quri.uri.file)
 
-(defstruct (uri-file (:include uri (scheme "file") (port nil))))
+(defstruct (uri-file (:include uri (scheme "file") (port nil))
+                     (:constructor %make-uri-file)))
+
+(defun make-uri-file (&rest initargs)
+  (let ((uri (apply #'%make-uri-file initargs)))
+    (when (pathnamep (uri-path uri))
+      (setf (uri-path uri)
+            (uiop:native-namestring (uri-path uri))))
+    uri))
 
 (declaim (ftype (function (uri-file) pathname) uri-file-pathname))
 (defun uri-file-pathname (file)

--- a/t/quri.lisp
+++ b/t/quri.lisp
@@ -173,4 +173,10 @@
         (render-uri (uri "//foo:80?a=5")))
       "//foo:80?a=5"))
 
+(subtest "coerce cl:pathname"
+  (is  (quri.uri:make-basic-uri :path "foo") (quri.uri:make-basic-uri :path #p"foo")
+       :test 'quri:uri=)
+  (is  (quri:make-uri-file :path "foo") (quri:make-uri-file :path #p"foo")
+       :test 'quri:uri=))
+
 (finalize)


### PR DESCRIPTION
Fixes #78.

@aadcg @aartaka Do you think this is extensive enough?