### PR TITLE
Feat: Switch from structs to clos

### DIFF
--- a/quri.asd
+++ b/quri.asd
@@ -7,6 +7,7 @@
                "alexandria"
                "split-sequence"
                "cl-utilities"
+	       "closer-mop"
                #+sbcl "sb-cltl2")
   :components ((:module "src"
                 :components

--- a/src/uri.lisp
+++ b/src/uri.lisp
@@ -3,6 +3,10 @@
   (:use :cl)
   (:import-from :quri.port
                 :scheme-default-port)
+  (:import-from #:closer-mop
+		#:defclass)
+  (:import-from #:alexandria
+		#:positive-integer)
   (:export :uri
            :make-basic-uri
            :uri-p
@@ -22,21 +26,51 @@
            :urn-nss))
 (in-package :quri.uri)
 
-(defstruct (uri (:constructor %make-uri))
-  (scheme nil :read-only t)
-  userinfo
-  host
-  port
-  path
-  query
-  fragment)
+(defclass uri ()
+  ((scheme :initarg :scheme
+	   :accessor uri-scheme
+	   :initform nil
+	   :type (or null string))
+   (userinfo :initarg :userinfo
+	     :accessor uri-userinfo
+	     :initform nil
+	     :type (or null string))
+   (host :initarg :host
+	 :accessor uri-host
+	 :initform nil
+	 :type (or null string))
+   (port :initarg :port
+	 :accessor uri-port
+	 :initform nil
+	 :type (or null positive-integer))
+   (path :initarg :path
+	 :accessor uri-path
+	 :initform nil
+	 :type (or null string pathname))
+   (query :initarg :query
+	  :accessor uri-query
+	  :initform nil
+	  :type (or null string))
+   (fragment :initarg :fragment
+	     :accessor uri-fragment
+	     :initform nil
+	     :type (or null string))))
+
+(declaim (ftype (function (t) boolean) uri-p urn-p))
+(defun uri-p (uri)
+  (typep uri (find-class 'uri)))
 
 (defmethod make-load-form ((object uri) &optional environment)
   (make-load-form-saving-slots object :environment environment))
 
-(defun make-basic-uri (&rest args &key scheme userinfo host port path query fragment)
+(declaim (ftype (function (&rest t &key (:scheme string) (:userinfo string)
+				 (:host string) (:port positive-integer)
+				 (:path (or string pathname))
+				 (:query string) (:fragment string)))
+		make-basic-uri))
+(defun make-basic-uri (&rest initargs &key scheme userinfo host port path query fragment)
   (declare (ignore scheme userinfo host port path query fragment))
-  (let ((uri (apply #'%make-uri args)))
+  (let ((uri (apply #'make-instance (cons 'uri initargs))))
     (unless (uri-port uri)
       (setf (uri-port uri) (scheme-default-port (uri-scheme uri))))
     (when (pathnamep (uri-path uri))
@@ -54,13 +88,24 @@
                 (eql (uri-port uri) default-port)
                 (uri-port uri))))))
 
-(defstruct (urn (:include uri (scheme :urn))
-                (:constructor %make-urn))
-  nid
-  nss)
+(defclass urn (uri)
+  ((nid :initarg nid
+	:accessor urn-nid
+	:initform :urn)
+   (nss :initarg nss
+	:accessor urn-nss
+	:initform nil)))
 
-(defun make-urn (&rest initargs)
-  (let ((urn (apply #'%make-urn initargs)))
+(defun urn-p (uri)
+  (typep uri (find-class 'urn)))
+
+(declaim (ftype (function (&rest t &key (:scheme string) (:userinfo string)
+				 (:host string) (:port positive-integer) (:path (or string pathname))
+				 (:query string) (:fragment string) (:nid t) (:nss t)))
+		make-urn))
+(defun make-urn (&rest initargs &key scheme userinfo host port path query fragment nid nss)
+  (declare (ignore scheme userinfo host port path query fragment nid nss))
+  (let ((urn (apply #'make-instance (cons 'urn initargs))))
     (when (uri-path urn)
       (let ((colon-pos (position #\: (uri-path urn))))
         (if colon-pos

--- a/src/uri/ftp.lisp
+++ b/src/uri/ftp.lisp
@@ -8,24 +8,47 @@
                 :uri-path)
   (:import-from :quri.port
                 :scheme-default-port)
+  (:import-from #:alexandria
+		#:positive-integer)
+  (:import-from #:closer-mop
+		#:defclass)
   (:export :uri-ftp
            :uri-ftp-p
            :uri-ftp-typecode
            :make-uri-ftp))
 (in-package :quri.uri.ftp)
 
-(defstruct (uri-ftp (:include uri (scheme "ftp") (port #.(scheme-default-port "ftp")))
-                    (:constructor %make-uri-ftp))
-  typecode)
+(defclass uri-ftp (uri)
+  ((scheme :initform "ftp"
+	   :initarg :scheme
+	   :accessor uri-ftp-scheme
+	   :type string)
+   (port :initform #.(scheme-default-port "ftp")
+	 :initarg :port
+	 :accessor uri-ftp-port
+	 :type (or null positive-integer))
+   (typecode :initform nil
+	     :initarg :typecode
+	     :accessor uri-ftp-typecode
+	     :type (or null string))))
 
-(defun make-uri-ftp (&rest initargs)
-  (let ((ftp (apply #'%make-uri-ftp initargs)))
+(declaim (ftype (function (&rest t &key (:scheme string) (:userinfo string)
+				 (:host string) (:port positive-integer) (:path (or string pathname))
+				 (:query string) (:fragment string) (:typecode string)))
+		make-uri-ftp))
+(defun make-uri-ftp (&rest initargs &key scheme userinfo host port path query fragment typecode)
+  (declare (ignore scheme userinfo host port path query fragment typecode))
+  (let ((ftp (apply #'make-instance (cons 'uri-ftp initargs))))
     (multiple-value-bind (path typecode)
         (parse-ftp-typecode (uri-path ftp))
       (when path
         (setf (uri-path ftp) path
               (uri-ftp-typecode ftp) typecode)))
     ftp))
+
+(declaim (ftype (function (t) boolean) uri-ftp-p))
+(defun uri-ftp-p (uri)
+  (typep uri (find-class 'uri-ftp)))
 
 (defun parse-ftp-typecode (path)
   (let ((len (length path)))

--- a/src/uri/http.lisp
+++ b/src/uri/http.lisp
@@ -13,7 +13,10 @@
   (:import-from :quri.decode
                 :url-decode-params)
   (:import-from :alexandria
-                :when-let)
+                #:when-let
+		#:positive-integer)
+  (:import-from #:closer-mop
+		#:defclass)
   (:export :uri-http
            :make-uri-http
            :uri-http-p
@@ -25,9 +28,44 @@
            :uri-query-params))
 (in-package :quri.uri.http)
 
-(defstruct (uri-http (:include uri (scheme "http") (port #.(scheme-default-port "http")))))
+(defclass uri-http (uri)
+  ((scheme :initform "http"
+	   :initarg :scheme
+	   :accessor uri-http-scheme
+	   :type string)
+   (port :initform #.(scheme-default-port "http")
+	 :initarg :port
+	 :accessor uri-http-port
+	 :type positive-integer)))
 
-(defstruct (uri-https (:include uri-http (scheme "https") (port #.(scheme-default-port "https")))))
+(declaim (ftype (function (&rest list &key (:scheme string) (:userinfo string)
+				 (:host string) (:port positive-integer) (:path (or string pathname))
+				 (:query string) (:fragment string)))
+		make-uri-http make-uri-https))
+(defun make-uri-http (&rest initargs &key scheme userinfo host port path query fragment)
+  (declare (ignore scheme userinfo host port path query fragment))
+  (apply #'make-instance (cons 'uri-http initargs)))
+
+(declaim (ftype (function (t) boolean) uri-http-p uri-https-p))
+(defun uri-http-p (uri)
+  (typep uri (find-class 'uri-http)))
+
+(defclass uri-https (uri)
+  ((scheme :initform "https"
+	   :initarg :scheme
+	   :accessor uri-https-scheme
+	   :type string)
+   (port :initform #.(scheme-default-port "https")
+	 :initarg :port
+	 :accessor uri-https-port
+	 :type positive-integer)))
+
+(defun make-uri-https (&rest args &key scheme userinfo host port path query fragment)
+  (declare (ignore scheme userinfo host port path query fragment))
+  (apply #'make-instance (cons 'uri-https args)))
+
+(defun uri-https-p (uri)
+  (typep uri (find-class 'uri-https)))
 
 (defun uri-query-params (http &key (lenient t))
   (when-let (query (uri-query http))

--- a/src/uri/ldap.lisp
+++ b/src/uri/ldap.lisp
@@ -11,8 +11,11 @@
                 :scheme-default-port)
   (:import-from :split-sequence
                 :split-sequence)
+  (:import-from #:closer-mop
+		#:defclass)
   (:import-from :alexandria
-                :when-let)
+                #:when-let
+		#:positive-integer)
   (:export :uri-ldap
            :make-uri-ldap
            :uri-ldap-p
@@ -28,9 +31,44 @@
            :uri-ldap-extensions))
 (in-package :quri.uri.ldap)
 
-(defstruct (uri-ldap (:include uri (scheme "ldap") (port #.(scheme-default-port "ldap")))))
+(defclass uri-ldap (uri)
+  ((scheme :initform "ldap"
+	   :initarg :scheme
+	   :accessor uri-ldap-scheme
+	   :type string)
+   (port :initform #.(scheme-default-port "ldap")
+	 :initarg :port
+	 :accessor uri-ldap-port
+	 :type positive-integer)))
 
-(defstruct (uri-ldaps (:include uri-ldap (scheme "ldaps") (port #.(scheme-default-port "ldaps")))))
+(declaim (ftype (function (&rest list &key (:scheme string) (:userinfo string)
+				 (:host string) (:port positive-integer) (:path (or string pathname))
+				 (:query string) (:fragment string)))
+		make-uri-ldap make-uri-ldaps))
+(defun make-uri-ldap (&rest initargs &key scheme userinfo host port path query fragment)
+  (declare (ignore scheme userinfo host port path query fragment))
+  (apply #'make-instance (cons 'uri-ldap initargs)))
+
+(declaim (ftype (function (t) boolean) uri-ldaps-p uri-ldap-p))
+(defun uri-ldap-p (uri)
+  (typep uri (find-class 'uri-ldap)))
+
+(defclass uri-ldaps (uri)
+  ((scheme :initform "ldaps"
+	   :initarg :scheme
+	   :accessor uri-ldaps-scheme
+	   :type string)
+   (port :initform #.(scheme-default-port "ldaps")
+	 :initarg :port
+	 :accessor uri-ldaps-port
+	 :type positive-integer)))
+
+(defun make-uri-ldaps (&rest initargs &key scheme userinfo host port path query fragment)
+  (declare (ignore scheme userinfo host port path query fragment))
+  (apply #'make-instance (cons 'uri-ldaps initargs)))
+
+(defun uri-ldaps-p (uri)
+  (typep uri (find-class 'uri-ldaps)))
 
 (defun uri-ldap-dn (ldap)
   (let ((path (uri-path ldap)))


### PR DESCRIPTION
- convert structs to classes: uri, urn, uri-ftp, uri-file, uri-http, uri-https, uri-ldap, uri-ldaps
- use closer-mop for defclass
- manually added uri-p, urn-p, uri-file-p, uri-ftp-p, uri-http-p, uri-https-p, uri-ldap-p, uri-ldaps-p
- remove %make-uri, %make-urn, %make-uri-ftp, %make-uri-file, %make-uri-ftp since its only used once respectively
- add/updated constructors: make-basic-uri, make-urn, make-uri-file, make-uri-ftp, make-uri-http, make-uri-https, make-uri-ldap, make-uri-ldaps
- add type declarations to changed functions

Questions:
- The tests are succeeding. Should more tests be added (e.g. with change-class?)?
- Most slots are initialized to nil, to avoid unbound slot error. 
  Is that desirable?
- should most slots have an accessor or reader only?
- urn nid and nss are not typed 
  (was not sure if they are string only or also other types allowed)

#58 @genworks 