### PR TITLE
Add a possibility to skip percent encoding of parameters

### DIFF
--- a/src/uri/http.lisp
+++ b/src/uri/http.lisp
@@ -29,12 +29,16 @@
 
 (defstruct (uri-https (:include uri-http (scheme "https") (port #.(scheme-default-port "https")))))
 
-(defun uri-query-params (http &key (lenient t))
+(defun uri-query-params (http &key (lenient t) (percent-decode t))
   (when-let (query (uri-query http))
-    (url-decode-params query :lenient lenient)))
+    (url-decode-params query
+                       :lenient lenient
+                       :percent-decode percent-decode)))
 
-(defun (setf uri-query-params) (new http &key lenient)
+(defun (setf uri-query-params) (new http &key lenient (percent-encode t))
   (declare (ignore lenient))
-  (setf (uri-query http) (if new
-                             (url-encode-params new)
-                             nil)))
+  (setf (uri-query http)
+        (if new
+            (url-encode-params
+             new :percent-encode percent-encode)
+            nil)))

--- a/t/decode.lisp
+++ b/t/decode.lisp
@@ -15,6 +15,14 @@
     '(("a" . "b") ("c" . "d") ("e"))
     "field only")
 
+(is (url-decode-params "alpha=%D0%B0%D0%B1%D0%B2")
+    '(("alpha" . "абв"))
+    "percent decode")
+
+(is (url-decode-params "alpha=%D0%B0%D0%B1%D0%B2" :percent-decode nil)
+    '(("alpha" . "%D0%B0%D0%B1%D0%B2"))
+    "no percent decode")
+
 (is-error (url-decode-params "a=b=c")
           'quri:uri-malformed-urlencoded-string
           "Raise a malformed error")

--- a/t/encode.lisp
+++ b/t/encode.lisp
@@ -26,6 +26,10 @@
       "a=b&c=1")
   (is (let ((*print-base* 2))
         (url-encode-params '(("a" . 5))))
-      "a=5"))
+      "a=5")
+  (is (url-encode-params '(("alpha" . "абв")))
+      "alpha=%D0%B0%D0%B1%D0%B2")
+  (is (url-encode-params '(("alpha" . "абв")) :percent-encode nil)
+      "alpha=абв"))
 
 (finalize)


### PR DESCRIPTION
For rationale for this, see https://github.com/atlas-engineer/nyxt/pull/3403